### PR TITLE
Hc 923 sql db backup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,17 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  
   - package-ecosystem: "terraform"
     directory: "/terraform/source"
     schedule:
       interval: "weekly"
       day: "sunday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 5 # default, let's see how we go
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"] # let's have more control over major changes
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,32 @@
+name: Generate terraform docs
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      ACCESS_TOKEN: ${{ github.actor == 'dependabot[bot]' && secrets.PAT_dependabot01 || secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ env.ACCESS_TOKEN }}
+
+      - name: Print Actor Name
+        run: echo "The actor is ${{ github.actor }}"
+
+      - name: Render terraform docs and push changes back to PR
+        uses: terraform-docs/gh-actions@main
+        with:
+          find-dir: ./terraform
+          output-file: README.md
+          output-method: inject
+          git-push: "true"
+        env:
+          ACCESS_TOKEN: ${{ github.actor == 'dependabot[bot]' && secrets.PAT_dependabot01 || secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The Terraform code in this repository creates backup policies in a specified Rec
 
 Additionally this repository can also be used to configure backup policies (only) for SQL in Azure Database. The backup policy can then be used to discover and associate a SQL database for `Full`, `Differential` or `Log` backup of the databases as per requirement.
 
+Please note at this time discovering and associating SQL DB to the backup workload policy is not possible via terraform azurerm provider. This can thus be done via portal, cli or powershell.
+
 ## Pre-requisites
 
 This configuration is intended for managing backups for existing VMs. The VMs and the Recovery Services vault should already exist in Azure.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ protection_policies = list(object({
       })
     }))
 
-    
+    Please look for a sample in Dev/testsub folder of this repository.    
 ```
 
 - `Sample`

--- a/terraform/environments/dev/eucs-uprint/README.md
+++ b/terraform/environments/dev/eucs-uprint/README.md
@@ -1,0 +1,55 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | =1.5.7 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.84.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.84.0 |
+| <a name="provider_azurerm.spoke"></a> [azurerm.spoke](#provider\_azurerm.spoke) | 3.84.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_backup_policy_vm.policy](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_policy_vm) | resource |
+| [azurerm_backup_policy_vm_workload.example](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_policy_vm_workload) | resource |
+| [azurerm_backup_protected_vm.vm](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_protected_vm) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/client_config) | data source |
+| [azurerm_recovery_services_vault.existing](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/recovery_services_vault) | data source |
+| [azurerm_resource_group.vault](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/resource_group) | data source |
+| [azurerm_virtual_machine.vm](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/virtual_machine) | data source |
+| [terraform_remote_state.alz_core_hub](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_action_groups"></a> [action\_groups](#input\_action\_groups) | Action group definitions. | <pre>map(object({<br>    resource_group    = string<br>    location          = string<br>    action_group_name = string<br>    email_config      = list(map(string))<br>    logic_app_config  = list(map(string))<br>  }))</pre> | `null` | no |
+| <a name="input_backup_policies"></a> [backup\_policies](#input\_backup\_policies) | The backup policies. | <pre>list(object({<br>    name        = string<br>    policy_type = string<br>    backup = object({<br>      frequency     = string<br>      time          = string<br>      hour_interval = optional(string)<br>      hour_duration = optional(string)<br>    })<br>    retention_daily = optional(object({<br>      count = number<br>    }))<br>    retention_weekly = optional(object({<br>      weekdays = list(string)<br>      count    = number<br>    }))<br>    retention_monthly = optional(object({<br>      count    = number<br>      weekdays = optional(list(string))<br>      weeks    = optional(list(string))<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_backup_workload_policies"></a> [backup\_workload\_policies](#input\_backup\_workload\_policies) | A list of backup workload policy configurations. Includes support for 'Full', 'Differential', and 'Log' policy types. | <pre>list(object({<br>    name                = string<br>    resource_group_name = string<br>    recovery_vault_name = string<br>    workload_type       = string<br>    settings            = object({<br>      time_zone           = string<br>      compression_enabled = bool<br>    })<br>    protection_policies = list(object({<br>      policy_type = string // Can be 'Full', 'Differential', or 'Log'<br>      backup = object({<br>        frequency              = string // Used for 'Full' and 'Differential', ignored for 'Log'<br>        time                   = string // Used for 'Full' and 'Differential', ignored for 'Log'<br>        frequency_in_minutes   = number // Used for 'Log', should be null or ignored for 'Full' and 'Differential'<br>      })<br>      retention_daily = object({<br>        count = number // Applicable for 'Full' and 'Differential' backups<br>      })<br>      simple_retention = object({<br>        count = number // Used for 'Log' backups<br>      })<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_custom_query_rules"></a> [custom\_query\_rules](#input\_custom\_query\_rules) | Configuration for Backup Alerts | <pre>map(object({<br>    description    = string<br>    resource_group = string<br>    scope          = string<br>    location       = string<br>    enabled        = bool<br>    severity       = number<br>    action_group   = string<br>    kql            = string<br>    criteria = object({<br>      aggregation             = string<br>      aggregation_granularity = string<br>      operator                = string<br>      threshold               = number<br>      measure_column          = string # not usually needed for "count" aggregation<br>      eval_frequency          = string<br>    })<br><br><br>  }))</pre> | `null` | no |
+| <a name="input_remote_state_hub_container"></a> [remote\_state\_hub\_container](#input\_remote\_state\_hub\_container) | Storage Account container that contains Hub state file | `string` | n/a | yes |
+| <a name="input_remote_state_hub_file"></a> [remote\_state\_hub\_file](#input\_remote\_state\_hub\_file) | State file name in Storage Account Container | `string` | n/a | yes |
+| <a name="input_remote_state_hub_rg_name"></a> [remote\_state\_hub\_rg\_name](#input\_remote\_state\_hub\_rg\_name) | Resource Group that contains core Hub state | `string` | n/a | yes |
+| <a name="input_remote_state_hub_sa_name"></a> [remote\_state\_hub\_sa\_name](#input\_remote\_state\_hub\_sa\_name) | Storage account that stores core Hub state | `string` | n/a | yes |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Spoke/Workload Subscription ID | `string` | n/a | yes |
+| <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | Tenant ID for this environment/subscription | `string` | n/a | yes |
+| <a name="input_vault_name"></a> [vault\_name](#input\_vault\_name) | The name of the Recovery Services vault. | `string` | n/a | yes |
+| <a name="input_vault_resource_group_name"></a> [vault\_resource\_group\_name](#input\_vault\_resource\_group\_name) | The name of the resource group where the Recovery Services vault and backup policies are located. | `string` | n/a | yes |
+| <a name="input_vms"></a> [vms](#input\_vms) | Information about the VMs to backup. | <pre>map(object({<br>    resource_group = string<br>    backup_policy  = string<br>  }))</pre> | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/terraform/environments/dev/hub/README.md
+++ b/terraform/environments/dev/hub/README.md
@@ -1,0 +1,55 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | =1.5.7 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.84.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.64.0 |
+| <a name="provider_azurerm.spoke"></a> [azurerm.spoke](#provider\_azurerm.spoke) | 3.64.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_backup_policy_vm.policy](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_policy_vm) | resource |
+| [azurerm_backup_policy_vm_workload.example](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_policy_vm_workload) | resource |
+| [azurerm_backup_protected_vm.vm](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_protected_vm) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/client_config) | data source |
+| [azurerm_recovery_services_vault.existing](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/recovery_services_vault) | data source |
+| [azurerm_resource_group.vault](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/resource_group) | data source |
+| [azurerm_virtual_machine.vm](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/virtual_machine) | data source |
+| [terraform_remote_state.alz_core_hub](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_action_groups"></a> [action\_groups](#input\_action\_groups) | Action group definitions. | <pre>map(object({<br>    resource_group    = string<br>    location          = string<br>    action_group_name = string<br>    email_config      = list(map(string))<br>    logic_app_config  = list(map(string))<br>  }))</pre> | `null` | no |
+| <a name="input_backup_policies"></a> [backup\_policies](#input\_backup\_policies) | The backup policies. | <pre>list(object({<br>    name        = string<br>    policy_type = string<br>    backup = object({<br>      frequency     = string<br>      time          = string<br>      hour_interval = optional(string)<br>      hour_duration = optional(string)<br>    })<br>    retention_daily = optional(object({<br>      count = number<br>    }))<br>    retention_weekly = optional(object({<br>      weekdays = list(string)<br>      count    = number<br>    }))<br>    retention_monthly = optional(object({<br>      count    = number<br>      weekdays = optional(list(string))<br>      weeks    = optional(list(string))<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_backup_workload_policies"></a> [backup\_workload\_policies](#input\_backup\_workload\_policies) | A list of backup workload policy configurations. Includes support for 'Full', 'Differential', and 'Log' policy types. | <pre>list(object({<br>    name                = string<br>    resource_group_name = string<br>    recovery_vault_name = string<br>    workload_type       = string<br>    settings            = object({<br>      time_zone           = string<br>      compression_enabled = bool<br>    })<br>    protection_policies = list(object({<br>      policy_type = string // Can be 'Full', 'Differential', or 'Log'<br>      backup = object({<br>        frequency              = string // Used for 'Full' and 'Differential', ignored for 'Log'<br>        time                   = string // Used for 'Full' and 'Differential', ignored for 'Log'<br>        frequency_in_minutes   = number // Used for 'Log', should be null or ignored for 'Full' and 'Differential'<br>      })<br>      retention_daily = object({<br>        count = number // Applicable for 'Full' and 'Differential' backups<br>      })<br>      simple_retention = object({<br>        count = number // Used for 'Log' backups<br>      })<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_custom_query_rules"></a> [custom\_query\_rules](#input\_custom\_query\_rules) | Configuration for Backup Alerts | <pre>map(object({<br>    description    = string<br>    resource_group = string<br>    scope          = string<br>    location       = string<br>    enabled        = bool<br>    severity       = number<br>    action_group   = string<br>    kql            = string<br>    criteria = object({<br>      aggregation             = string<br>      aggregation_granularity = string<br>      operator                = string<br>      threshold               = number<br>      measure_column          = string # not usually needed for "count" aggregation<br>      eval_frequency          = string<br>    })<br><br><br>  }))</pre> | `null` | no |
+| <a name="input_remote_state_hub_container"></a> [remote\_state\_hub\_container](#input\_remote\_state\_hub\_container) | Storage Account container that contains Hub state file | `string` | n/a | yes |
+| <a name="input_remote_state_hub_file"></a> [remote\_state\_hub\_file](#input\_remote\_state\_hub\_file) | State file name in Storage Account Container | `string` | n/a | yes |
+| <a name="input_remote_state_hub_rg_name"></a> [remote\_state\_hub\_rg\_name](#input\_remote\_state\_hub\_rg\_name) | Resource Group that contains core Hub state | `string` | n/a | yes |
+| <a name="input_remote_state_hub_sa_name"></a> [remote\_state\_hub\_sa\_name](#input\_remote\_state\_hub\_sa\_name) | Storage account that stores core Hub state | `string` | n/a | yes |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Spoke/Workload Subscription ID | `string` | n/a | yes |
+| <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | Tenant ID for this environment/subscription | `string` | n/a | yes |
+| <a name="input_vault_name"></a> [vault\_name](#input\_vault\_name) | The name of the Recovery Services vault. | `string` | n/a | yes |
+| <a name="input_vault_resource_group_name"></a> [vault\_resource\_group\_name](#input\_vault\_resource\_group\_name) | The name of the resource group where the Recovery Services vault and backup policies are located. | `string` | n/a | yes |
+| <a name="input_vms"></a> [vms](#input\_vms) | Information about the VMs to backup. | <pre>map(object({<br>    resource_group = string<br>    backup_policy  = string<br>  }))</pre> | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/terraform/environments/dev/testsub/.terraform.lock.hcl
+++ b/terraform/environments/dev/testsub/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.84.0"
+  constraints = "3.84.0"
+  hashes = [
+    "h1:aoqNC2sfLKyblgQh0SfQW0BHl3UP1mMAUJLYLGG3PxE=",
+    "zh:14a96daf672541dbc27137d9cc0a96a737710597262ecaaa64a328eb1174e5df",
+    "zh:16d8e794fdd87ed8e64291fe8a617f420d8263f21672033333a020d06f4c9618",
+    "zh:64e5cd1bb6a81bccffff0d1f77790286ab46179cf12442134c3f3bca722afc1b",
+    "zh:7010ada67fbae971ac8b7204a30b1317aee7ccac7227afc6ac27277c642996a1",
+    "zh:77c2616ecd29685d2a4dc3ec3e9771e5ecf652e127946767d9b7ef19bbf58a21",
+    "zh:861922cfae724eacf1bd915efd5dbf6c23e4e762a2bbe60993099648e64aedb5",
+    "zh:8fb797c98bb08e7342995317810d28c41bb519fbc128adaa170896356b9eaebd",
+    "zh:982e85a4a9d282e3c8f7d7836037ccc98ff3ef50af246fad2e04684a81d16201",
+    "zh:a2ef29ff907cf6622e58afa0a27e23a3160ba3d70d531795b4d9a6c42c354630",
+    "zh:c46ccc4eecb79d096bcb652af0cffe300ec480d80a13a5b302c71b1aac9f9f1c",
+    "zh:cc6a06bf6d5e811fe8c0d9ad652e143b4e94bd16a03fb8a86f5086f0ae5abfa9",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/environments/dev/testsub/README.md
+++ b/terraform/environments/dev/testsub/README.md
@@ -1,0 +1,55 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | =1.5.7 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.84.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.84.0 |
+| <a name="provider_azurerm.spoke"></a> [azurerm.spoke](#provider\_azurerm.spoke) | 3.84.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_backup_policy_vm.policy](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_policy_vm) | resource |
+| [azurerm_backup_policy_vm_workload.example](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_policy_vm_workload) | resource |
+| [azurerm_backup_protected_vm.vm](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_protected_vm) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/client_config) | data source |
+| [azurerm_recovery_services_vault.existing](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/recovery_services_vault) | data source |
+| [azurerm_resource_group.vault](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/resource_group) | data source |
+| [azurerm_virtual_machine.vm](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/virtual_machine) | data source |
+| [terraform_remote_state.alz_core_hub](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_action_groups"></a> [action\_groups](#input\_action\_groups) | Action group definitions. | <pre>map(object({<br>    resource_group    = string<br>    location          = string<br>    action_group_name = string<br>    email_config      = list(map(string))<br>    logic_app_config  = list(map(string))<br>  }))</pre> | `null` | no |
+| <a name="input_backup_policies"></a> [backup\_policies](#input\_backup\_policies) | The backup policies. | <pre>list(object({<br>    name        = string<br>    policy_type = string<br>    backup = object({<br>      frequency     = string<br>      time          = string<br>      hour_interval = optional(string)<br>      hour_duration = optional(string)<br>    })<br>    retention_daily = optional(object({<br>      count = number<br>    }))<br>    retention_weekly = optional(object({<br>      weekdays = list(string)<br>      count    = number<br>    }))<br>    retention_monthly = optional(object({<br>      count    = number<br>      weekdays = optional(list(string))<br>      weeks    = optional(list(string))<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_backup_workload_policies"></a> [backup\_workload\_policies](#input\_backup\_workload\_policies) | A list of backup workload policy configurations. Includes support for 'Full', 'Differential', and 'Log' policy types. | <pre>list(object({<br>    name                = string<br>    resource_group_name = string<br>    recovery_vault_name = string<br>    workload_type       = string<br>    settings            = object({<br>      time_zone           = string<br>      compression_enabled = bool<br>    })<br>    protection_policies = list(object({<br>      policy_type = string // Can be 'Full', 'Differential', or 'Log'<br>      backup = object({<br>        frequency              = string // Used for 'Full' and 'Differential', ignored for 'Log'<br>        time                   = string // Used for 'Full' and 'Differential', ignored for 'Log'<br>        frequency_in_minutes   = number // Used for 'Log', should be null or ignored for 'Full' and 'Differential'<br>      })<br>      retention_daily = object({<br>        count = number // Applicable for 'Full' and 'Differential' backups<br>      })<br>      simple_retention = object({<br>        count = number // Used for 'Log' backups<br>      })<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_custom_query_rules"></a> [custom\_query\_rules](#input\_custom\_query\_rules) | Configuration for Backup Alerts | <pre>map(object({<br>    description    = string<br>    resource_group = string<br>    scope          = string<br>    location       = string<br>    enabled        = bool<br>    severity       = number<br>    action_group   = string<br>    kql            = string<br>    criteria = object({<br>      aggregation             = string<br>      aggregation_granularity = string<br>      operator                = string<br>      threshold               = number<br>      measure_column          = string # not usually needed for "count" aggregation<br>      eval_frequency          = string<br>    })<br><br><br>  }))</pre> | `null` | no |
+| <a name="input_remote_state_hub_container"></a> [remote\_state\_hub\_container](#input\_remote\_state\_hub\_container) | Storage Account container that contains Hub state file | `string` | n/a | yes |
+| <a name="input_remote_state_hub_file"></a> [remote\_state\_hub\_file](#input\_remote\_state\_hub\_file) | State file name in Storage Account Container | `string` | n/a | yes |
+| <a name="input_remote_state_hub_rg_name"></a> [remote\_state\_hub\_rg\_name](#input\_remote\_state\_hub\_rg\_name) | Resource Group that contains core Hub state | `string` | n/a | yes |
+| <a name="input_remote_state_hub_sa_name"></a> [remote\_state\_hub\_sa\_name](#input\_remote\_state\_hub\_sa\_name) | Storage account that stores core Hub state | `string` | n/a | yes |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Spoke/Workload Subscription ID | `string` | n/a | yes |
+| <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | Tenant ID for this environment/subscription | `string` | n/a | yes |
+| <a name="input_vault_name"></a> [vault\_name](#input\_vault\_name) | The name of the Recovery Services vault. | `string` | n/a | yes |
+| <a name="input_vault_resource_group_name"></a> [vault\_resource\_group\_name](#input\_vault\_resource\_group\_name) | The name of the resource group where the Recovery Services vault and backup policies are located. | `string` | n/a | yes |
+| <a name="input_vms"></a> [vms](#input\_vms) | Information about the VMs to backup. | <pre>map(object({<br>    resource_group = string<br>    backup_policy  = string<br>  }))</pre> | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/terraform/environments/dev/testsub/backend.tf
+++ b/terraform/environments/dev/testsub/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "azurerm" {
+    storage_account_name = "samojtfstate001"
+    resource_group_name  = "rg-terraform-statefiles-001"
+    container_name       = "tfstate"
+    key                  = "devtest-vm-worload-backup.terraform.tfstate"
+  }
+}

--- a/terraform/environments/dev/testsub/backup-policies.auto.tfvars
+++ b/terraform/environments/dev/testsub/backup-policies.auto.tfvars
@@ -1,0 +1,31 @@
+vault_resource_group_name = "rg-ns-demo-TF"
+vault_name                = "RSV-test-demo"
+
+backup_policies = [
+  {
+    name        = "Policy-sqls-vm-backup"
+    policy_type = "V2"
+    backup = {
+      frequency = "Daily"
+      time      = "23:00"
+    }
+    retention_daily = {
+      count = 14
+    }
+    retention_weekly = {
+      count    = 12
+      weekdays = ["Sunday"]
+    }
+    retention_monthly = {
+      count    = 12
+      weekdays = ["Sunday"]
+      weeks    = ["First"]
+    }
+  }
+]
+# In this example:
+
+# The backup is taken daily at 11:00 PM.
+# Daily backups are retained for 14 days.
+# Weekly backups (taken every Sunday) are retained for 3 weeks.
+# Monthly backups are retained for 4 months.

--- a/terraform/environments/dev/testsub/backup-workload-policies.auto.tfvars
+++ b/terraform/environments/dev/testsub/backup-workload-policies.auto.tfvars
@@ -1,0 +1,42 @@
+backup_workload_policies = [
+  {
+    name                = "sqlbackup01"
+    resource_group_name = "rg-ns-demo-TF"
+    recovery_vault_name = "RSV-test-demo"
+    workload_type       = "SQLDataBase"
+    settings            = {
+      time_zone           = "UTC"
+      compression_enabled = false
+    }
+    protection_policies = [
+      {
+        policy_type = "Full"
+        backup = {
+          frequency = "Daily"
+          time      = "15:00"
+          frequency_in_minutes = null
+        }
+        retention_daily = {
+          count = 8
+        }
+        simple_retention = {
+          count = null
+        }
+      },
+      {
+        policy_type = "Log"
+        backup = {
+          frequency = null
+          time      = null
+          frequency_in_minutes = 15
+        }
+        retention_daily = {
+          count = null
+        }
+        simple_retention = {
+          count = 8
+        }
+      }
+    ]
+  }
+]

--- a/terraform/environments/dev/testsub/data.tf
+++ b/terraform/environments/dev/testsub/data.tf
@@ -1,0 +1,1 @@
+../../../source/data.tf

--- a/terraform/environments/dev/testsub/main.tf
+++ b/terraform/environments/dev/testsub/main.tf
@@ -1,0 +1,1 @@
+../../../source/main.tf

--- a/terraform/environments/dev/testsub/terraform.tfvars
+++ b/terraform/environments/dev/testsub/terraform.tfvars
@@ -1,0 +1,8 @@
+tenant_id       = "0bb413d7-160d-4839-868a-f3d46537f6af"
+subscription_id = "4b068872-d9f3-41bc-9c34-ffac17cf96d6" # devtest
+
+#For looking up data values from the core Hub state
+remote_state_hub_sa_name   = "samojtfstate001"
+remote_state_hub_rg_name   = "rg-terraform-statefiles-001"
+remote_state_hub_container = "tfstate"
+remote_state_hub_file      = "hubdev.terraform.tfstate"

--- a/terraform/environments/dev/testsub/variables.tf
+++ b/terraform/environments/dev/testsub/variables.tf
@@ -1,0 +1,1 @@
+../../../source/variables.tf

--- a/terraform/environments/dev/testsub/versions.tf
+++ b/terraform/environments/dev/testsub/versions.tf
@@ -1,0 +1,1 @@
+../../../source/versions.tf

--- a/terraform/environments/dev/testsub/vm-backup-config.auto.tfvars
+++ b/terraform/environments/dev/testsub/vm-backup-config.auto.tfvars
@@ -1,0 +1,7 @@
+vms = {
+  vmsql002 = {
+    resource_group = "rg-ns-demo-TF"
+    backup_policy  = "Policy-sqls-vm-backup"
+  }
+}
+

--- a/terraform/environments/prod/sserv/README.md
+++ b/terraform/environments/prod/sserv/README.md
@@ -1,0 +1,55 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | =1.5.7 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.84.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.84.0 |
+| <a name="provider_azurerm.spoke"></a> [azurerm.spoke](#provider\_azurerm.spoke) | 3.84.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_backup_policy_vm.policy](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_policy_vm) | resource |
+| [azurerm_backup_policy_vm_workload.example](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_policy_vm_workload) | resource |
+| [azurerm_backup_protected_vm.vm](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_protected_vm) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/client_config) | data source |
+| [azurerm_recovery_services_vault.existing](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/recovery_services_vault) | data source |
+| [azurerm_resource_group.vault](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/resource_group) | data source |
+| [azurerm_virtual_machine.vm](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/virtual_machine) | data source |
+| [terraform_remote_state.alz_core_hub](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_action_groups"></a> [action\_groups](#input\_action\_groups) | Action group definitions. | <pre>map(object({<br>    resource_group    = string<br>    location          = string<br>    action_group_name = string<br>    email_config      = list(map(string))<br>    logic_app_config  = list(map(string))<br>  }))</pre> | `null` | no |
+| <a name="input_backup_policies"></a> [backup\_policies](#input\_backup\_policies) | The backup policies. | <pre>list(object({<br>    name        = string<br>    policy_type = string<br>    backup = object({<br>      frequency     = string<br>      time          = string<br>      hour_interval = optional(string)<br>      hour_duration = optional(string)<br>    })<br>    retention_daily = optional(object({<br>      count = number<br>    }))<br>    retention_weekly = optional(object({<br>      weekdays = list(string)<br>      count    = number<br>    }))<br>    retention_monthly = optional(object({<br>      count    = number<br>      weekdays = optional(list(string))<br>      weeks    = optional(list(string))<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_backup_workload_policies"></a> [backup\_workload\_policies](#input\_backup\_workload\_policies) | A list of backup workload policy configurations. Includes support for 'Full', 'Differential', and 'Log' policy types. | <pre>list(object({<br>    name                = string<br>    resource_group_name = string<br>    recovery_vault_name = string<br>    workload_type       = string<br>    settings            = object({<br>      time_zone           = string<br>      compression_enabled = bool<br>    })<br>    protection_policies = list(object({<br>      policy_type = string // Can be 'Full', 'Differential', or 'Log'<br>      backup = object({<br>        frequency              = string // Used for 'Full' and 'Differential', ignored for 'Log'<br>        time                   = string // Used for 'Full' and 'Differential', ignored for 'Log'<br>        frequency_in_minutes   = number // Used for 'Log', should be null or ignored for 'Full' and 'Differential'<br>      })<br>      retention_daily = object({<br>        count = number // Applicable for 'Full' and 'Differential' backups<br>      })<br>      simple_retention = object({<br>        count = number // Used for 'Log' backups<br>      })<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_custom_query_rules"></a> [custom\_query\_rules](#input\_custom\_query\_rules) | Configuration for Backup Alerts | <pre>map(object({<br>    description    = string<br>    resource_group = string<br>    scope          = string<br>    location       = string<br>    enabled        = bool<br>    severity       = number<br>    action_group   = string<br>    kql            = string<br>    criteria = object({<br>      aggregation             = string<br>      aggregation_granularity = string<br>      operator                = string<br>      threshold               = number<br>      measure_column          = string # not usually needed for "count" aggregation<br>      eval_frequency          = string<br>    })<br><br><br>  }))</pre> | `null` | no |
+| <a name="input_remote_state_hub_container"></a> [remote\_state\_hub\_container](#input\_remote\_state\_hub\_container) | Storage Account container that contains Hub state file | `string` | n/a | yes |
+| <a name="input_remote_state_hub_file"></a> [remote\_state\_hub\_file](#input\_remote\_state\_hub\_file) | State file name in Storage Account Container | `string` | n/a | yes |
+| <a name="input_remote_state_hub_rg_name"></a> [remote\_state\_hub\_rg\_name](#input\_remote\_state\_hub\_rg\_name) | Resource Group that contains core Hub state | `string` | n/a | yes |
+| <a name="input_remote_state_hub_sa_name"></a> [remote\_state\_hub\_sa\_name](#input\_remote\_state\_hub\_sa\_name) | Storage account that stores core Hub state | `string` | n/a | yes |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Spoke/Workload Subscription ID | `string` | n/a | yes |
+| <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | Tenant ID for this environment/subscription | `string` | n/a | yes |
+| <a name="input_vault_name"></a> [vault\_name](#input\_vault\_name) | The name of the Recovery Services vault. | `string` | n/a | yes |
+| <a name="input_vault_resource_group_name"></a> [vault\_resource\_group\_name](#input\_vault\_resource\_group\_name) | The name of the resource group where the Recovery Services vault and backup policies are located. | `string` | n/a | yes |
+| <a name="input_vms"></a> [vms](#input\_vms) | Information about the VMs to backup. | <pre>map(object({<br>    resource_group = string<br>    backup_policy  = string<br>  }))</pre> | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/terraform/source/README.md
+++ b/terraform/source/README.md
@@ -1,0 +1,55 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | =1.5.7 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.84.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.84.0 |
+| <a name="provider_azurerm.spoke"></a> [azurerm.spoke](#provider\_azurerm.spoke) | 3.84.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_backup_policy_vm.policy](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_policy_vm) | resource |
+| [azurerm_backup_policy_vm_workload.example](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_policy_vm_workload) | resource |
+| [azurerm_backup_protected_vm.vm](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/backup_protected_vm) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/client_config) | data source |
+| [azurerm_recovery_services_vault.existing](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/recovery_services_vault) | data source |
+| [azurerm_resource_group.vault](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/resource_group) | data source |
+| [azurerm_virtual_machine.vm](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/data-sources/virtual_machine) | data source |
+| [terraform_remote_state.alz_core_hub](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_action_groups"></a> [action\_groups](#input\_action\_groups) | Action group definitions. | <pre>map(object({<br>    resource_group    = string<br>    location          = string<br>    action_group_name = string<br>    email_config      = list(map(string))<br>    logic_app_config  = list(map(string))<br>  }))</pre> | `null` | no |
+| <a name="input_backup_policies"></a> [backup\_policies](#input\_backup\_policies) | The backup policies. | <pre>list(object({<br>    name        = string<br>    policy_type = string<br>    backup = object({<br>      frequency     = string<br>      time          = string<br>      hour_interval = optional(string)<br>      hour_duration = optional(string)<br>    })<br>    retention_daily = optional(object({<br>      count = number<br>    }))<br>    retention_weekly = optional(object({<br>      weekdays = list(string)<br>      count    = number<br>    }))<br>    retention_monthly = optional(object({<br>      count    = number<br>      weekdays = optional(list(string))<br>      weeks    = optional(list(string))<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_backup_workload_policies"></a> [backup\_workload\_policies](#input\_backup\_workload\_policies) | A list of backup workload policy configurations. Includes support for 'Full', 'Differential', and 'Log' policy types. | <pre>list(object({<br>    name                = string<br>    resource_group_name = string<br>    recovery_vault_name = string<br>    workload_type       = string<br>    settings            = object({<br>      time_zone           = string<br>      compression_enabled = bool<br>    })<br>    protection_policies = list(object({<br>      policy_type = string // Can be 'Full', 'Differential', or 'Log'<br>      backup = object({<br>        frequency              = string // Used for 'Full' and 'Differential', ignored for 'Log'<br>        time                   = string // Used for 'Full' and 'Differential', ignored for 'Log'<br>        frequency_in_minutes   = number // Used for 'Log', should be null or ignored for 'Full' and 'Differential'<br>      })<br>      retention_daily = object({<br>        count = number // Applicable for 'Full' and 'Differential' backups<br>      })<br>      simple_retention = object({<br>        count = number // Used for 'Log' backups<br>      })<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_custom_query_rules"></a> [custom\_query\_rules](#input\_custom\_query\_rules) | Configuration for Backup Alerts | <pre>map(object({<br>    description    = string<br>    resource_group = string<br>    scope          = string<br>    location       = string<br>    enabled        = bool<br>    severity       = number<br>    action_group   = string<br>    kql            = string<br>    criteria = object({<br>      aggregation             = string<br>      aggregation_granularity = string<br>      operator                = string<br>      threshold               = number<br>      measure_column          = string # not usually needed for "count" aggregation<br>      eval_frequency          = string<br>    })<br><br><br>  }))</pre> | `null` | no |
+| <a name="input_remote_state_hub_container"></a> [remote\_state\_hub\_container](#input\_remote\_state\_hub\_container) | Storage Account container that contains Hub state file | `string` | n/a | yes |
+| <a name="input_remote_state_hub_file"></a> [remote\_state\_hub\_file](#input\_remote\_state\_hub\_file) | State file name in Storage Account Container | `string` | n/a | yes |
+| <a name="input_remote_state_hub_rg_name"></a> [remote\_state\_hub\_rg\_name](#input\_remote\_state\_hub\_rg\_name) | Resource Group that contains core Hub state | `string` | n/a | yes |
+| <a name="input_remote_state_hub_sa_name"></a> [remote\_state\_hub\_sa\_name](#input\_remote\_state\_hub\_sa\_name) | Storage account that stores core Hub state | `string` | n/a | yes |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Spoke/Workload Subscription ID | `string` | n/a | yes |
+| <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | Tenant ID for this environment/subscription | `string` | n/a | yes |
+| <a name="input_vault_name"></a> [vault\_name](#input\_vault\_name) | The name of the Recovery Services vault. | `string` | n/a | yes |
+| <a name="input_vault_resource_group_name"></a> [vault\_resource\_group\_name](#input\_vault\_resource\_group\_name) | The name of the resource group where the Recovery Services vault and backup policies are located. | `string` | n/a | yes |
+| <a name="input_vms"></a> [vms](#input\_vms) | Information about the VMs to backup. | <pre>map(object({<br>    resource_group = string<br>    backup_policy  = string<br>  }))</pre> | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/terraform/source/main.tf
+++ b/terraform/source/main.tf
@@ -55,6 +55,9 @@ resource "azurerm_backup_protected_vm" "vm" {
 }
 
 resource "azurerm_backup_policy_vm_workload" "example" {
+
+  provider = azurerm.spoke
+  
   for_each = { for idx, policy in var.backup_workload_policies : idx => policy }
 
   name                = each.value.name

--- a/terraform/source/main.tf
+++ b/terraform/source/main.tf
@@ -53,3 +53,53 @@ resource "azurerm_backup_protected_vm" "vm" {
 
   depends_on = [azurerm_backup_policy_vm.policy]
 }
+
+resource "azurerm_backup_policy_vm_workload" "example" {
+  for_each = { for idx, policy in var.backup_workload_policies : idx => policy }
+
+  name                = each.value.name
+  resource_group_name = each.value.resource_group_name
+  recovery_vault_name = each.value.recovery_vault_name
+  workload_type       = each.value.workload_type
+
+  settings {
+    time_zone           = each.value.settings.time_zone
+    compression_enabled = each.value.settings.compression_enabled
+  }
+
+  dynamic "protection_policy" {
+    for_each = each.value.protection_policies
+    content {
+      policy_type = protection_policy.value.policy_type
+
+      dynamic "backup" {
+        for_each = protection_policy.value.policy_type == "Log" ? [protection_policy.value.backup] : []
+        content {
+          frequency_in_minutes = backup.value.frequency_in_minutes
+        }
+      }
+
+      dynamic "backup" {
+        for_each = protection_policy.value.policy_type == "Full" ? [protection_policy.value.backup] : []
+        content {
+          frequency = backup.value.frequency
+          time      = backup.value.time
+        }
+      }
+
+      dynamic "retention_daily" {
+        for_each = protection_policy.value.policy_type == "Full" ? [protection_policy.value.retention_daily] : []
+        content {
+          count = retention_daily.value.count
+        }
+      }
+
+      dynamic "simple_retention" {
+        for_each = protection_policy.value.policy_type == "Log" ? [protection_policy.value.simple_retention] : []
+        content {
+          count = simple_retention.value.count
+        }
+      }
+    }
+  }
+}

--- a/terraform/source/main.tf
+++ b/terraform/source/main.tf
@@ -54,8 +54,62 @@ resource "azurerm_backup_protected_vm" "vm" {
   depends_on = [azurerm_backup_policy_vm.policy]
 }
 
-resource "azurerm_backup_policy_vm_workload" "example" {
+# resource "azurerm_backup_policy_vm_workload" "example" {
 
+#   provider = azurerm.spoke
+
+#   for_each = { for idx, policy in var.backup_workload_policies : idx => policy }
+
+#   name                = each.value.name
+#   resource_group_name = each.value.resource_group_name
+#   recovery_vault_name = each.value.recovery_vault_name
+#   workload_type       = each.value.workload_type
+
+#   settings {
+#     time_zone           = each.value.settings.time_zone
+#     compression_enabled = each.value.settings.compression_enabled
+#   }
+
+#   dynamic "protection_policy" {
+#     for_each = each.value.protection_policies
+#     content {
+#       policy_type = protection_policy.value.policy_type
+
+#       dynamic "backup" {
+#         for_each = protection_policy.value.policy_type == "Log" ? [protection_policy.value.backup] : []
+#         content {
+#           frequency_in_minutes = backup.value.frequency_in_minutes
+#         }
+#       }
+
+#       dynamic "backup" {
+#         for_each = protection_policy.value.policy_type == "Full" ? [protection_policy.value.backup] : []
+#         content {
+#           frequency = backup.value.frequency
+#           time      = backup.value.time
+#         }
+#       }
+
+#       dynamic "retention_daily" {
+#         for_each = protection_policy.value.policy_type == "Full" ? [protection_policy.value.retention_daily] : []
+#         content {
+#           count = retention_daily.value.count
+#         }
+#       }
+
+#       dynamic "simple_retention" {
+#         for_each = protection_policy.value.policy_type == "Log" ? [protection_policy.value.simple_retention] : []
+#         content {
+#           count = simple_retention.value.count
+#         }
+#       }
+#     }
+#   }
+# }
+
+
+
+resource "azurerm_backup_policy_vm_workload" "example" {
   provider = azurerm.spoke
   
   for_each = { for idx, policy in var.backup_workload_policies : idx => policy }
@@ -90,8 +144,23 @@ resource "azurerm_backup_policy_vm_workload" "example" {
         }
       }
 
+      dynamic "backup" {
+        for_each = protection_policy.value.policy_type == "Differential" ? [protection_policy.value.backup] : []
+        content {
+          frequency = backup.value.frequency
+          time      = backup.value.time
+        }
+      }
+
       dynamic "retention_daily" {
         for_each = protection_policy.value.policy_type == "Full" ? [protection_policy.value.retention_daily] : []
+        content {
+          count = retention_daily.value.count
+        }
+      }
+
+      dynamic "retention_daily" {
+        for_each = protection_policy.value.policy_type == "Differential" ? [protection_policy.value.retention_daily] : []
         content {
           count = retention_daily.value.count
         }

--- a/terraform/source/variables.tf
+++ b/terraform/source/variables.tf
@@ -92,7 +92,7 @@ variable "backup_policies" {
 # Variable for backup vm workload like sql and saphana
 
 variable "backup_workload_policies" {
-  description = "A list of backup workload policy configurations"
+  description = "A list of backup workload policy configurations. Includes support for 'Full', 'Differential', and 'Log' policy types."
   type = list(object({
     name                = string
     resource_group_name = string
@@ -103,22 +103,23 @@ variable "backup_workload_policies" {
       compression_enabled = bool
     })
     protection_policies = list(object({
-      policy_type = string
+      policy_type = string // Can be 'Full', 'Differential', or 'Log'
       backup = object({
-        frequency              = string
-        time                   = string
-        frequency_in_minutes   = number
+        frequency              = string // Used for 'Full' and 'Differential', ignored for 'Log'
+        time                   = string // Used for 'Full' and 'Differential', ignored for 'Log'
+        frequency_in_minutes   = number // Used for 'Log', should be null or ignored for 'Full' and 'Differential'
       })
       retention_daily = object({
-        count = number
+        count = number // Applicable for 'Full' and 'Differential' backups
       })
       simple_retention = object({
-        count = number
+        count = number // Used for 'Log' backups
       })
     }))
   }))
   default = []
 }
+
 
 
 # Variables for Alerts

--- a/terraform/source/variables.tf
+++ b/terraform/source/variables.tf
@@ -85,7 +85,41 @@ variable "backup_policies" {
       weeks    = optional(list(string))
     }))
   }))
+  default = []
 }
+
+
+# Variable for backup vm workload like sql and saphana
+
+variable "backup_workload_policies" {
+  description = "A list of backup workload policy configurations"
+  type = list(object({
+    name                = string
+    resource_group_name = string
+    recovery_vault_name = string
+    workload_type       = string
+    settings            = object({
+      time_zone           = string
+      compression_enabled = bool
+    })
+    protection_policies = list(object({
+      policy_type = string
+      backup = object({
+        frequency              = string
+        time                   = string
+        frequency_in_minutes   = number
+      })
+      retention_daily = object({
+        count = number
+      })
+      simple_retention = object({
+        count = number
+      })
+    }))
+  }))
+  default = []
+}
+
 
 # Variables for Alerts
 


### PR DESCRIPTION
This PR contains the updates to the existing code. Specifically it introduces the azurerm_backup_policy_vm_workload.
It allows user to self serve and create a backup_workload_policy which can be subsequently used in azure portal to discover and backup sql databases.
The policy can be configured to have Full, Differential and log protection policies and their specific retention duration.

The readme is updated to reflect this additional feature . The readme also has links to the pre-requisities needed for a successful sql on azure backup configuration.

Readme also mentions the fact that at this time it is only possible to create the backup policy for sql backups. The enrolling, discovery of sql dbs in not a feature yet present in azure rm provider . This will need to be taken care via portal.

It also clarifies what attibute to use when choosing full, differential or log protection ( backup) policy as the values change depending on the backup type.

There is also a sample deployment in dev--testsub folder.