### PR TITLE
removing sql bkp policy assignment

### DIFF
--- a/terraform/environments/prod/smss-iBase/vm-backup-config.auto.tfvars
+++ b/terraform/environments/prod/smss-iBase/vm-backup-config.auto.tfvars
@@ -10,11 +10,3 @@ vms = {
     backup_policy  = "daily-backup-policy-1"
   }
 }
-
-wk_vms = {
-  vm-ibase-sql1 = {
-    resource_group = "rg-smss-ibase-001"
-    backup_policy  = "ibasesqlbackup01"
-  }
-
-}

--- a/terraform/source/main.tf
+++ b/terraform/source/main.tf
@@ -54,17 +54,6 @@ resource "azurerm_backup_protected_vm" "vm" {
   depends_on = [azurerm_backup_policy_vm.policy]
 }
 
-resource "azurerm_backup_protected_vm" "vm-sql" {
-  provider = azurerm.spoke
-  for_each = var.wk_vms != null ? var.wk_vms : {}
-
-  resource_group_name = data.azurerm_resource_group.vault.name
-  recovery_vault_name = data.azurerm_recovery_services_vault.existing.name
-  source_vm_id        = data.azurerm_virtual_machine.vm[each.key].id
-  backup_policy_id    = azurerm_backup_policy_vm_workload.backup_workload_policies[each.value.backup_policy].id
-
-  depends_on = [azurerm_backup_policy_vm_workload.backup_workload_policies]
-}
 ## Backup workload policy resource used for SQL in Azure and SAPHANA workload policies
 
 resource "azurerm_backup_policy_vm_workload" "backup_workload_policies" {

--- a/terraform/source/variables.tf
+++ b/terraform/source/variables.tf
@@ -62,14 +62,6 @@ variable "vms" {
 }
 
 
-variable "wk_vms" {
-  description = "Information about the VMs to backup."
-  type = map(object({
-    resource_group = string
-    backup_policy  = string
-  }))
-  default = {}
-}
 variable "backup_policies" {
   description = "The backup policies."
   type = list(object({


### PR DESCRIPTION
Removing sql bkp policy assignment as it is not working suitably with terraform.

We are instead just creating the sql workload backup policy via code.

the actual assignment of this policy to a sql server is then done via portal and which includes steps of db discovery, installing an azureworkload extention etc.