### PR TITLE
HC-1048 add chronicle dogs dev

### DIFF
--- a/terraform/environments/dev/smss-dogs/backend.tf
+++ b/terraform/environments/dev/smss-dogs/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "azurerm" {
+    storage_account_name = "samojtfstate001"
+    resource_group_name  = "rg-terraform-statefiles-001"
+    container_name       = "tfstate"
+    key                  = "dogs-vm-backup.terraform.tfstate"
+  }
+}

--- a/terraform/environments/dev/smss-dogs/backup-policies.auto.tfvars
+++ b/terraform/environments/dev/smss-dogs/backup-policies.auto.tfvars
@@ -1,0 +1,13 @@
+backup_policies = [
+  {
+    name        = "daily-backup-policy-dogs"
+    policy_type = "V2"
+    backup = {
+      frequency = "Daily"
+      time      = "20:00"
+    }
+    retention_daily = {
+      count = 14
+    }
+  }
+]

--- a/terraform/environments/dev/smss-dogs/backup-workload-policies.auto.tfvars
+++ b/terraform/environments/dev/smss-dogs/backup-workload-policies.auto.tfvars
@@ -1,0 +1,42 @@
+backup_workload_policies = [
+  {
+    name                = "dogssqlbackup01"
+    resource_group_name = "rg-smss-core-001"
+    recovery_vault_name = "rsv-smss-core-001"
+    workload_type       = "SQLDataBase"
+    settings = {
+      time_zone           = "UTC"
+      compression_enabled = false
+    }
+    protection_policies = [
+      {
+        policy_type = "Full"
+        backup = {
+          frequency            = "Daily"
+          time                 = "22:00"
+          frequency_in_minutes = null
+        }
+        retention_daily = {
+          count = 8
+        }
+        simple_retention = {
+          count = null
+        }
+      },
+      {
+        policy_type = "Log"
+        backup = {
+          frequency            = null
+          time                 = null
+          frequency_in_minutes = 15
+        }
+        retention_daily = {
+          count = null
+        }
+        simple_retention = {
+          count = 8
+        }
+      }
+    ]
+  }
+]

--- a/terraform/environments/dev/smss-dogs/data.tf
+++ b/terraform/environments/dev/smss-dogs/data.tf
@@ -1,0 +1,1 @@
+../../../source/data.tf

--- a/terraform/environments/dev/smss-dogs/main.tf
+++ b/terraform/environments/dev/smss-dogs/main.tf
@@ -1,0 +1,1 @@
+../../../source/main.tf

--- a/terraform/environments/dev/smss-dogs/terraform.tfvars
+++ b/terraform/environments/dev/smss-dogs/terraform.tfvars
@@ -1,0 +1,8 @@
+tenant_id       = "0bb413d7-160d-4839-868a-f3d46537f6af" # devl.justice.gov.uk
+subscription_id = "1694d62a-08ca-48d5-93b6-0feb07d8bce3" # MoJ-ALZ-Devl-Spoke-SmallServices
+
+#For looking up data values from the core Hub state
+remote_state_hub_sa_name   = "samojtfstate001"
+remote_state_hub_rg_name   = "rg-terraform-statefiles-001"
+remote_state_hub_container = "tfstate"
+remote_state_hub_file      = "hubdev.terraform.tfstate"

--- a/terraform/environments/dev/smss-dogs/variables.tf
+++ b/terraform/environments/dev/smss-dogs/variables.tf
@@ -1,0 +1,1 @@
+../../../source/variables.tf

--- a/terraform/environments/dev/smss-dogs/versions.tf
+++ b/terraform/environments/dev/smss-dogs/versions.tf
@@ -1,0 +1,1 @@
+../../../source/versions.tf

--- a/terraform/environments/dev/smss-dogs/vm-backup-config.auto.tfvars
+++ b/terraform/environments/dev/smss-dogs/vm-backup-config.auto.tfvars
@@ -1,0 +1,14 @@
+vault_resource_group_name = "rg-smss-core-001"
+vault_name                = "rsv-smss-core-001"
+
+# Workload vm to backup
+vms = {
+  vm-dogs-app01 = {
+    resource_group = "rg-smss-dogs-001"
+    backup_policy  = "daily-backup-policy-dogs"
+  }
+  vm-dogs-sql01 = {
+    resource_group = "rg-smss-dogs-001"
+    backup_policy  = "daily-backup-policy-dogs"
+  }
+}


### PR DESCRIPTION
Onboards vm and sql workload in **dev** of smss Chronicle Dog Application into backup for [HC-1048](https://dsdmoj.atlassian.net/browse/HC-1048).