### PR TITLE
Fix the GitHub Actions semantic sha hashes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo "The actor is ${{ github.actor }}"
 
       - name: Render terraform docs and push changes back to PR
-        uses: terraform-docs/gh-actions@Aeae0038ed47a547e0c0fca5c059d3335f48fb25 # v1.3.0
+        uses: terraform-docs/gh-actions@aeae0038ed47a547e0c0fca5c059d3335f48fb25 # v1.3.0
         with:
           find-dir: ./terraform
           output-file: README.md


### PR DESCRIPTION
Correcting first letter of the sha hash version for `terraform-docs/gh-actions` which had been capitalised causing Dependabot not to be able to recognise the version.
 
This is the error that this PR is resolving:
```
Dependabot could not resolve semantic versions for dependencies :
terraform-docs/gh-actions
```