### PR TITLE
HC-1322 Pinning the Github Action Version To V18.6.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "ministryofjustice/github-actions"
+        # Ignore versions greater than 18.6.0
+        versions: [">=18.6.1"]
   
   - package-ecosystem: "terraform"
     directory: "/terraform/source"


### PR DESCRIPTION
The GitHub actions and workflows currently provided by ministryofjustice/github-actions are being decommissioned so we should not update to v19.0.0 as per the announcement on [Releases · ministryofjustice/github-actions](https://github.com/ministryofjustice/github-actions/releases)

Short term fix will be to pin to v18.6.0 and add an ignore for ministryofjustice/github-actions in all of our dependabot.yml files
https://dsdmoj.atlassian.net/browse/HC-1322